### PR TITLE
feat(ingress-nginx): increase shutdown time to 600s

### DIFF
--- a/modules/ingress-nginx/values.yaml
+++ b/modules/ingress-nginx/values.yaml
@@ -5,7 +5,9 @@ controller:
   config:
     use-forwarded-headers: "true"
     use-proxy-protocol: "true"
+    worker-shutdown-timeout: "600s"
   replicaCount: 3
+  terminationGracePeriodSeconds: 600
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration change, but it affects ingress availability during rollouts by extending pod termination/drain timing and NGINX worker shutdown behavior.
> 
> **Overview**
> In `modules/ingress-nginx/values.yaml`, increases ingress-nginx graceful shutdown behavior by setting `controller.config.worker-shutdown-timeout` to `600s` and `controller.terminationGracePeriodSeconds` to `600`.
> 
> This is intended to give NGINX more time to drain connections during termination/rollouts, potentially lengthening how long pods take to fully stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89329a5523dff345a298b5846709f6fd018102b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->