### PR TITLE
fix(mongodb): correct private_link_id reference in privatelink_endpoint service resource

### DIFF
--- a/modules/mongodb/main.tf
+++ b/modules/mongodb/main.tf
@@ -26,7 +26,7 @@ resource "mongodbatlas_privatelink_endpoint" "this" {
 resource "mongodbatlas_privatelink_endpoint_service" "this" {
   project_id          = mongodbatlas_privatelink_endpoint.this.project_id
   endpoint_service_id = aws_vpc_endpoint.this.id
-  private_link_id     = mongodbatlas_privatelink_endpoint.this.id
+  private_link_id     = mongodbatlas_privatelink_endpoint.this.private_link_id
   provider_name       = "AWS"
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches MongoDB Atlas private link wiring; a wrong ID can fail Terraform or break VPC-to-Atlas connectivity, but the change is a single-attribute correction aligned with the provider API.
> 
> **Overview**
> Fixes **`mongodbatlas_privatelink_endpoint_service`** so `private_link_id` is set from **`mongodbatlas_privatelink_endpoint.this.private_link_id`** instead of the endpoint resource’s Terraform **`id`**.
> 
> Atlas expects the provider’s private link identifier when linking the AWS VPC endpoint to the Atlas private endpoint; using the wrong attribute can break apply or leave private link misconfigured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d1c87cf7921a450708d0f4bc07619e90191c1a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->