### PR TITLE
fix: allow all TCP from VPC on endpoint security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,8 +110,11 @@ module "endpoints" {
   security_group_name        = "${var.name}-endpoints"
   security_group_description = "VPC endpoint default security group"
   security_group_rules = {
-    ingress_https = {
-      description = "HTTPS from VPC"
+    ingress_all_tcp = {
+      description = "All TCP from VPC"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "tcp"
       cidr_blocks = [local.vpc_cidr]
     }
   }


### PR DESCRIPTION
## RATIONALE

The endpoint security group (added in #35) allows 443 only. That drops traffic to non-443 custom PrivateLink endpoints — e.g. an endpoint service (NLB) fronting an RDS Postgres instance on 5432 — regardless of any consuming Kubernetes NetworkPolicy, so those endpoints are unreachable. [FLEET-7059](https://datarobot.atlassian.net/browse/FLEET-7059) needs custom endpoints on arbitrary ports to work.

## CHANGES

- Endpoint security group now allows all TCP from the VPC CIDR (was 443-only).

## NOTES

- Access stays bounded to the VPC CIDR; the consuming NetworkPolicy (omnistrate-poc `vpc_endpoint_ipblocks` -> `core.networkPolicy.extraEgress`, scoped to the endpoint `/32`s) remains the finer-grained restriction. This matches the all-ports behavior of the Cilium policy this replaces.
- omnistrate-poc pins this module at `v6.5.0`; this change (and #35) must be in that tag.
